### PR TITLE
Fix download with aria2c

### DIFF
--- a/R/s2_download.R
+++ b/R/s2_download.R
@@ -180,13 +180,15 @@ s2_download <- function(
         
         binpaths <- load_binpaths("aria2")
         if (Sys.info()["sysname"] != "Windows") {
-          link <- gsub("/\\$value", "/\\\\$value", link)
+          link_aria <- gsub("/\\$value", "/\\\\$value", link)
+        } else {
+          link_aria <- link
         }
         aria_string <- paste0(
           binpaths$aria2c, " -x 2 --check-certificate=false -d ",
           dirname(zip_path),
           " -o ", basename(zip_path),
-          " ", "\"", as.character(link), "\"",
+          " ", "\"", as.character(link_aria), "\"",
           " --allow-overwrite --file-allocation=none --retry-wait=2",
           " --http-user=", "\"", creds[1], "\"",
           " --http-passwd=", "\"", creds[2], "\"",


### PR DESCRIPTION
Simple fix to avoid crash on download when using aria due to changes to s2_download introduced in a774498ab9c3db02ffbf8597f5cc6a740610a39d

(was failing in creating a safelist on "links" with added backslashes used on aria download on linux, such as  https://scihub.copernicus.eu/apihub/odata/v1/Products('f3d1966b-97c6-4448-9465-fbd6905d132a')/\\$value
)