### PR TITLE
Missing packages to run the GUI: revised install.packages() call.

### DIFF
--- a/R/check_gui_deps.R
+++ b/R/check_gui_deps.R
@@ -44,8 +44,8 @@ check_gui_deps <- function(abort = TRUE) {
       type = ifelse(abort, "error", "warning"),
       "Some missing packages are needed to run the GUI; ",
       "please install them with the command \n",
-      " > install.packages(\"",
-      paste(names(gui_deps_missing)[gui_deps_missing], collapse = "\", \""),"\")"
+      " > install.packages(c(\"",
+      paste(names(gui_deps_missing)[gui_deps_missing], collapse = "\", \""),"\"))"
     )
     invisible(TRUE)
   } else {

--- a/vignettes/sen2r_gui.Rmd
+++ b/vignettes/sen2r_gui.Rmd
@@ -23,7 +23,7 @@ sen2r()
 Note that the following error message could be returned:
 ```
 Some missing packages are needed to run the GUI; please install them with the command
-> install.packages("leaflet", "leafpm", "mapedit", "shiny", "shinyFiles", "shinydashboard", "shinyjs", "shinyWidgets")
+> install.packages(c("leaflet", "leafpm", "mapedit", "shiny", "shinyFiles", "shinydashboard", "shinyjs", "shinyWidgets"))
 ```
 This because "graphical" packages required to run the GUI are now suggested dependencies (the package could be used without them, if the user do not require the GUI).
 In this case, simply install the missing packages as stated by the error message (which could differ from the previous one).


### PR DESCRIPTION
I started with a clean install of **sen2r**. Not having a bunch of shiny related pkgs installed &ndash; and hence simply copying the `install.packages()` call suggested by `sen2r()` &ndash; I ran into the following issue:

![image](https://user-images.githubusercontent.com/3940660/88372195-b6dd5080-cd95-11ea-82e5-0fd53b9a5cfe.png)

I believe this behavior is rather unintended and can easily be resolved through this PR. `sessionInfo()` attached.

<details>
  <summary>sessionInfo()</summary>
  
  ```r
R version 4.0.2 (2020-06-22)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19041)

Matrix products: default

locale:
[1] LC_COLLATE=German_Germany.1252  LC_CTYPE=German_Germany.1252   
[3] LC_MONETARY=German_Germany.1252 LC_NUMERIC=C                   
[5] LC_TIME=German_Germany.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] sen2r_1.3.7.9001

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.5         pillar_1.4.6       compiler_4.0.2     class_7.3-17      
 [5] iterators_1.0.12   tools_4.0.2        jsonlite_1.7.0     lifecycle_0.2.0   
 [9] tibble_3.0.3       lattice_0.20-41    pkgconfig_2.0.3    rlang_0.4.7       
[13] foreach_1.5.0      DBI_1.1.0          rstudioapi_0.11    rgdal_1.5-12      
[17] crul_0.9.0         curl_4.3           parallel_4.0.2     geojson_0.3.4     
[21] geojsonio_0.9.2    e1071_1.7-3        raster_3.3-13      httr_1.4.2        
[25] jqr_1.1.0          dplyr_1.0.0        generics_0.0.2     vctrs_0.3.2       
[29] rgeos_0.5-3        classInt_0.4-3     grid_4.0.2         prompt_1.0.0      
[33] tidyselect_1.1.0   httpcode_0.3.0     glue_1.4.1         data.table_1.12.8 
[37] sf_0.9-5           R6_2.4.1           XML_3.99-0.4       foreign_0.8-80    
[41] sp_1.4-2           purrr_0.3.4        magrittr_1.5       stars_0.4-3       
[45] maptools_1.0-1     clisymbols_1.2.0   codetools_0.2-16   ellipsis_0.3.1    
[49] units_0.6-7        abind_1.4-5        V8_3.2.0           KernSmooth_2.23-17
[53] lazyeval_0.2.2     RcppTOML_0.1.6     doParallel_1.0.15  lwgeom_0.2-5      
[57] crayon_1.3.4 
  ```
</details>
