### PR TITLE
Update scihub_login.R

### DIFF
--- a/R/scihub_login.R
+++ b/R/scihub_login.R
@@ -80,7 +80,7 @@ check_scihub_login <- function(username, password) {
   }
   check_creds <- RETRY(
     verb = "GET",
-    url = "https://scihub.copernicus.eu/apihub/odata/v1",
+    url = "https://scihub.copernicus.eu/dhus",
     handle = handle(""),
     config = authenticate(username, password)
   )


### PR DESCRIPTION
I believe that Copernicus changed their API endpoint, I am no longer able to access using my credentials at the previous one. Changing the endpoint in both SCP in QGIS as well as the endpoint in the check_scihub_login function fixed the login problem for me.